### PR TITLE
PERA-2629 Use extra amount instead of extracted for arc59 calculation

### DIFF
--- a/sdk/transaction.go
+++ b/sdk/transaction.go
@@ -839,7 +839,7 @@ func MakeOptInAndAssetTransferTxns(
 			}
 		}
 
-		if senderExtractedAmountInt64-senderExtractedMinBalanceInt64 < receiverExtractedAmountInt64+FLAT_FEE+FLAT_FEE {
+		if senderExtractedAmountInt64-senderExtractedMinBalanceInt64 < receiverExtraAlgoAmount+FLAT_FEE+FLAT_FEE {
 			err = fmt.Errorf("sender does not have enough algo to cover recivers needs")
 			return
 		}
@@ -921,15 +921,14 @@ func MakeOptInAndAssetTransferTxns(
 	}
 }
 
-
 // Calculate the min balance amount needed by the receiver account
 func GetReceiverMinBalanceFee(
-	receiverAlgoAmount, 
+	receiverAlgoAmount,
 	receiverMinBalanceAmount *Uint64,
 ) (receiverMinBalanceFee int, err error) {
 	const (
 		ASSET_OPT_IN_MBR uint64 = 100000
-		ACCOUNT_MBR uint64 = 100000
+		ACCOUNT_MBR      uint64 = 100000
 	)
 
 	receiverExtractedAmount, err := receiverAlgoAmount.Extract()


### PR DESCRIPTION
## Description
Fixed a bug in MakeOptInAndAssetTransferTxns that caused transactions to fail when sending assets to accounts where the total amount is bigger than sender's available balance. 

For an example, if receiver had 1,000 ALGO and needed 0.1 ALGO for an opt-in, the code forced sender to have at least 1,000 ALGO to proceed. If sender had only 100 ALGO, the transaction would fail unnecessarily even if sender has enough algo to cover expenses.

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-2629
